### PR TITLE
[Fixed JENKINS-21305] Fix help text - comma separator for multiple labels

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/elasticaxisplugin/ElasticAxis/help-labelString.html
+++ b/src/main/resources/org/jenkinsci/plugins/elasticaxisplugin/ElasticAxis/help-labelString.html
@@ -1,4 +1,4 @@
 <div>
-  <p>The label of nodes on which the build will take place. You can specify multiple labels separated by spaces. Example:</p>
-  <p>label_1 label_2</p>
+  <p>The label of nodes on which the build will take place. You can specify multiple labels separated by commas. Example:</p>
+  <p>label_1,label_2</p>
 </div>


### PR DESCRIPTION
The original help stated that multiple labels can be specified when
separated by space, yet the code implements separating labels by comma
rather than space.
