### PR TITLE
Fix for [JENKINS-19162] elastic-axis: a dummy "Jenkins" node is added to the list of candidates

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/elasticaxisplugin/ElasticAxis.java
+++ b/src/main/java/org/jenkinsci/plugins/elasticaxisplugin/ElasticAxis.java
@@ -68,7 +68,7 @@ public class ElasticAxis extends LabelAxis {
 		for (String aLabel : labels) {
 			for(Node node : Jenkins.getInstance().getLabel(aLabel.trim()).getNodes()) {
 				if (shouldAddNode(restrictToOnlineNodes, node.toComputer())) 
-					computedNodes.add(node.getDisplayName());
+					computedNodes.add(node.getSelfLabel().getExpression());
 			}
 		}
 		


### PR DESCRIPTION
Hi,

This change should fix issue [JENKINS-19162]: elastic-axis: a dummy "Jenkins" node is added to the list of candidates.

The problem was that because the master node has display name "Jenkins", a "Jenkins" label was added to the list of candidates. This should have been the label "master". By using the 'self' label for building the list of labels, instead of the display name,  the correct label is added for the master node.

Regards,
Wilco
