### PR TITLE
Allow builds to be once per label, not for everything in a label

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/elasticaxisplugin/ElasticAxis/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/elasticaxisplugin/ElasticAxis/config.jelly
@@ -9,4 +9,7 @@
   <f:entry title="${%Skip building on offline nodes}" field="ignoreOffline">
      <f:checkbox/>
    </f:entry> 
+  <f:entry title="${%Build once per label}" field="dontExpandLabels">
+     <f:checkbox/>
+   </f:entry> 
 </j:jelly>


### PR DESCRIPTION
Closes: https://issues.jenkins-ci.org/browse/JENKINS-27420

We have some unreliable builders where we need to skip offline nodes. This functionality alresady exists in elastic-axis-plugin. However, when builders are online, we only need to build once per label, not on all nodes within a label. This commit adds a tickbox with this option, so e.g. if label=centos-s390x Jenkins will only build on one matching builder, if possible.