### PR TITLE
Release from a GitHub action with automatic version

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,78 @@
+---
+name: cd
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 8
+
+      - name: Wait for build to succeed
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-build
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Jenkins
+
+      - name: next release version
+        id: nextversion
+        uses: jenkins-x-plugins/jx-release-version@v2.4.2
+
+      - name: Set Version
+        run: |
+          mvn --no-transfer-progress versions:set -DnewVersion=${{ steps.nextversion.outputs.version }}
+      - name: Release Drafter
+        uses: release-drafter/release-drafter@v5.15.0
+        if: steps.wait-for-build.outputs.conclusion == 'success'
+        with:
+          name: next
+          tag: next
+          version: next
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Interesting
+        id: interesting
+        if: steps.wait-for-build.outputs.conclusion == 'success'
+        run: |
+          set -euxo pipefail
+          echo $GITHUB_EVENT_NAME
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]
+          then
+            INTERESTING_CATEGORIES='[💥🚨🎉🐛⚠🚀👷]|:(boom|tada|construction_worker):'
+            CATEGORIES=$(gh api /repos/$GITHUB_REPOSITORY/releases | jq -e -r '.[] | select(.draft == true and .name == "next") | .body')
+            if echo "${CATEGORIES}" | egrep -q "${INTERESTING_CATEGORIES}"; then
+              echo "Interesting release"
+              echo "::set-output name=should_release::true"
+            else
+              echo "Not interesting release"
+              echo "::set-output name=should_release::false"
+            fi
+          else
+            echo "::set-output name=should_release::true"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Release
+        uses: jenkins-infra/jenkins-maven-cd-action@master
+        if: steps.interesting.outputs.should_release == 'true'
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}


### PR DESCRIPTION
## Use conventional commits for automatic release versioning

Uses conventional commits to provide semantic versioning of plugin releases.

See https://www.conventionalcommits.org/en/v1.0.0/#summary
