### PR TITLE
Use GitHub registry for jx-release-version

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: next release version
         id: nextversion
-        uses: ghcr.io/jenkins-x/jx-release-version@2.4.13
+        uses: ghcr.io/jenkins-x/jx-release-version@v2.4.13
 
       - name: Set Version
         run: |

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: next release version
         id: nextversion
-        uses: ghcr.io/jenkins-x/jx-release-version:2.4.13
+        uses: ghcr.io/jenkins-x/jx-release-version@2.4.13
 
       - name: Set Version
         run: |

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: next release version
         id: nextversion
-        uses: jenkins-x-plugins/jx-release-version@v2.4.2
+        uses: ghcr.io/jenkins-x/jx-release-version:2.4.13
 
       - name: Set Version
         run: |

--- a/.github/workflows/report-version.yaml
+++ b/.github/workflows/report-version.yaml
@@ -21,4 +21,4 @@ jobs:
 
       - name: next release version
         id: nextversion
-        uses: ghcr.io/jenkins-x/jx-release-version:2.4.13
+        uses: ghcr.io/jenkins-x/jx-release-version@2.4.13

--- a/.github/workflows/report-version.yaml
+++ b/.github/workflows/report-version.yaml
@@ -21,4 +21,4 @@ jobs:
 
       - name: next release version
         id: nextversion
-        uses: jenkins-x-plugins/jx-release-version@v2.4.2
+        uses: ghcr.io/jenkins-x/jx-release-version:2.4.13

--- a/.github/workflows/report-version.yaml
+++ b/.github/workflows/report-version.yaml
@@ -21,4 +21,4 @@ jobs:
 
       - name: next release version
         id: nextversion
-        uses: ghcr.io/jenkins-x/jx-release-version@2.4.13
+        uses: ghcr.io/jenkins-x/jx-release-version@v2.4.13


### PR DESCRIPTION
## Pull jx-release-version from GitHub container registry

The docker registry for Jenkins X has been superseded by GitHub
container registry.
