### PR TITLE
Require Jenkins 2.289.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.263.1</jenkins.version>
+    <jenkins.version>2.289.1</jenkins.version>
     <java.level>8</java.level>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.failOnError>true</spotbugs.failOnError>
@@ -49,7 +49,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.263.x</artifactId>
+        <artifactId>bom-2.289.x</artifactId>
         <version>950.v396cb834de1e</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
## Require Jenkins 2.289.1 instead of 2.263.1
