### PR TITLE
Fix coverage reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.27</version>
+    <version>4.28</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## Fix coverage reporting during build

Use parent pom 4.28 instead of parent pom 4.27.
