### PR TITLE
Test Java 8 on Windows and Java 11 on Linux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,8 @@
 #!/usr/bin/env groovy
 
-buildPlugin()
+buildPlugin(
+  configurations: [
+    [platform: 'linux',   jdk: '11'],
+    [platform: 'windows', jdk:  '8']
+  ]
+)


### PR DESCRIPTION
## Test Java 11 on Linux, Java 8 on Windows

Assure that ci.jenkins.io includes Java 11 test configuration.

Intentionally keeping the number of platforms to the same so that costs do not increase.