### PR TITLE
Require POST for elastic axis checks

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/elasticaxisplugin/ElasticAxis.java
+++ b/src/main/java/org/jenkinsci/plugins/elasticaxisplugin/ElasticAxis.java
@@ -23,6 +23,7 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 
 public class ElasticAxis extends LabelAxis {
 
@@ -116,8 +117,10 @@ public class ElasticAxis extends LabelAxis {
                     formData.getBoolean("dontExpandLabels"));
         }
 
+        @RequirePOST
         public FormValidation doCheckLabelString(
                 @AncestorInPath Job<?, ?> job, @QueryParameter String value) {
+            job.checkPermission(hudson.model.Item.CONFIGURE);
             String[] labels = value.split(",");
             List<FormValidation> aggregatedNotOkValidations = new ArrayList<>();
             for (String oneLabel : labels) {
@@ -144,6 +147,7 @@ public class ElasticAxis extends LabelAxis {
             return FormValidation.ok();
         }
 
+        @RequirePOST
         public AutoCompletionCandidates doAutoCompleteLabelString(@QueryParameter String value) {
             return LabelExpression.autoComplete(value);
         }


### PR DESCRIPTION
## Require POST for label sanity checks

Also check that current context has permission to configure the job.

None of the checks are strictly required, since label checks are not an expensive operation, do not modify state, and are not exposing potentially sensitive information.  Better to resolve them in code than to dismiss them without a code change.
