### PR TITLE
Track GitHub actions dependencies with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
   - MarkEWaite
   labels:
   - skip-changelog
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly


### PR DESCRIPTION
## Track GitHub actions dependencies with Dependabot

Update GitHub action version numbers with dependabot
