### PR TITLE
Use spotless instead of tidy for formatting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,56 +84,48 @@
   </pluginRepositories>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>2.17.6</version>
+          <configuration>
+            <!-- define a language-specific format -->
+            <java>
+              <!-- no need to specify files, inferred automatically -->
+              <!-- apply a specific flavor of google-java-format -->
+              <googleJavaFormat>
+                <!-- Blocked at 1.7 until Java 8 google-java-format is no longer required -->
+                <version>1.7</version>
+                <style>AOSP</style>
+              </googleJavaFormat>
+              <endWithNewline></endWithNewline>
+              <removeUnusedImports></removeUnusedImports>
+            </java>
+            <pom>
+              <indent>
+                <spaces>true</spaces>
+              </indent>
+              <includes>
+                <include>pom.xml</include>
+              </includes>
+              <sortPom></sortPom>
+            </pom>
+          </configuration>
+          <executions>
+            <execution>
+              <!-- Runs in verify phase by default -->
+              <goals>
+                <!-- Can be disabled using -Dspotless.check.skip -->
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
-      <!-- Fail build on pom formatting errors -->
-      <!-- Fix with mvn tidy:pom -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>tidy-maven-plugin</artifactId>
-        <version>1.1.0</version>
-        <executions>
-          <execution>
-            <id>validate</id>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <phase>validate</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.17.6</version>
-        <configuration>
-          <!-- define a language-specific format -->
-          <java>
-            <!-- no need to specify files, inferred automatically -->
-            <!-- apply a specific flavor of google-java-format -->
-            <googleJavaFormat>
-              <!-- Blocked at 1.7 until Java 8 google-java-format is no longer required -->
-              <version>1.7</version>
-              <style>AOSP</style>
-            </googleJavaFormat>
-          </java>
-          <pom>
-            <indent>
-              <spaces>true</spaces>
-            </indent>
-            <includes>
-              <include>pom.xml</include>
-            </includes>
-            <sortPom></sortPom>
-          </pom>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
## Use spotless instead of tidy

Spotless supports more checks and more facilities.  Being used in Jenkins core now with good results.
