### PR TITLE
Label pom and contributing as maintenance

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,7 +5,9 @@ skip-changelog:
 - .settings/*
 - Jenkinsfile
 
-enhancement:
+chore:
 - pom.xml
 - CONTRIBUTING.md
+
+enhancement:
 - README.md


### PR DESCRIPTION
## Label pom and CONTRIBUTING changes as maintenance

They are not user visible changes so there is less motivation to default their label to "enhancement".
