### PR TITLE
Require Jenkins 2.332.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.319.3</jenkins.version>
+    <jenkins.version>2.332.4</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.failOnError>true</spotbugs.failOnError>
     <spotbugs.threshold>High</spotbugs.threshold>
@@ -47,7 +47,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.319.x</artifactId>
+        <artifactId>bom-2.332.x</artifactId>
         <version>1577.v63609d9cb_5dc</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
## Require Jenkins 2.332.4 or newer

Since I'm not checking older versions and 2.332.4 is one of the recommend Jenkins versions and there is a security advisory for Jenkins 2.332.3 and older, let's require 2.332.4 or newer.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
