### PR TITLE
Revert "Use CodeQL v2 scanner"

### DIFF
--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   security-scan:
-    uses: offa/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2_update
+    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
     with:
       java-cache: '' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
       java-version: 11 # What version of Java to set up for the build.


### PR DESCRIPTION
Reverts jenkinsci/elastic-axis-plugin#171

Harmless to have the deprecation message and easier to revert immediately than to remember to revert later

https://github.com/jenkins-infra/jenkins-security-scan/pull/10#issuecomment-1234576811