### PR TITLE
Use container agents on 50% of builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 buildPlugin(
   configurations: [
-    [platform: 'linux',   jdk: '17', jenkins: '2.344'],
+    [platform: 'linux',   jdk: '17', jenkins: '2.346.3'],
     [platform: 'linux',   jdk: '11'],
     [platform: 'windows', jdk:  '8']
   ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,11 @@
 #!/usr/bin/env groovy
 
+# Use container agents on odd numbered builds
+# Assures that we test with container agents and without container agents
+def useContainerForOddBuilds = ((BUILD_ID as int) % 2) as boolean
+
 buildPlugin(
+  useContainerAgent: useContainerForOddBuilds,
   configurations: [
     [platform: 'linux',   jdk: '17', jenkins: '2.346.3'],
     [platform: 'linux',   jdk: '11'],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
-# Use container agents on odd numbered builds
-# Assures that we test with container agents and without container agents
+// Use container agents on odd numbered builds
+// Assures that we test with container agents and without container agents
 def useContainerForOddBuilds = ((BUILD_ID as int) % 2) as boolean
 
 buildPlugin(


### PR DESCRIPTION
## Use container agents on 50% of builds

- Test JDK 17 with Jenkins 2.346.3 (latest LTS)
- Use container agents for odd numbered builds

Container agents sometimes detect issues that are not detected with agents running on virtual machines.  Test on both containers and virtual machines to assure surprises are detected early.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
