### PR TITLE
Require Jenkins core 2.346.3 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,8 +7,8 @@ def useContainerForOddBuilds = ((BUILD_ID as int) % 2) as boolean
 buildPlugin(
   useContainerAgent: useContainerForOddBuilds,
   configurations: [
-    [platform: 'linux',   jdk: '17', jenkins: '2.346.3'],
-    [platform: 'linux',   jdk: '11'],
+    [platform: 'linux',   jdk: '17', jenkins: '2.374'],
+    [platform: 'linux',   jdk: '11', jenkins: '2.361.2'],
     [platform: 'windows', jdk:  '8']
   ]
 )

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.332.4</jenkins.version>
+    <jenkins.version>2.346.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.failOnError>true</spotbugs.failOnError>
     <spotbugs.threshold>High</spotbugs.threshold>
@@ -47,7 +47,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.332.x</artifactId>
+        <artifactId>bom-2.346.x</artifactId>
         <version>1643.v1cffef51df73</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
## Require Jenkins 2.346.3 or newer

- Require Jenkins 2.346.3 or newer
- Test core 2.374, 2.361.2, and 2.346.3

The newer Jenkins versions are used by over 80% of the users of the 1.6.0 release.  That release was delivered 5 months ago.  Users that are adopting the current release of the plugin are also adopting the current Jenkins releases.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue (see Jenkinsfile)
