### PR TITLE
Remove unnecessary annotation exclusion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,12 +58,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
-      <exclusions>
-	<exclusion>
-	  <groupId>javax.annotation</groupId>
-	  <artifactId>javax.annotation-api</artifactId>
-	</exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>


### PR DESCRIPTION
## Remove unused annotation exclusion

Matrix project plugin no longer requires the exclusion

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~ - confirmed that the hpi file does not include any jar files related to transitive dependencies of matrix project plugin.
