### PR TITLE
Use Palantir format instead of Google Java Format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,12 +93,8 @@
             <!-- define a language-specific format -->
             <java>
               <!-- no need to specify files, inferred automatically -->
-              <!-- apply a specific flavor of google-java-format -->
-              <googleJavaFormat>
-                <version>1.15.0</version>
-                <style>AOSP</style>
-              </googleJavaFormat>
               <endWithNewline />
+              <palantirJavaFormat />
               <removeUnusedImports />
             </java>
             <pom>

--- a/src/main/java/org/jenkinsci/plugins/elasticaxisplugin/ElasticAxis.java
+++ b/src/main/java/org/jenkinsci/plugins/elasticaxisplugin/ElasticAxis.java
@@ -34,8 +34,7 @@ public class ElasticAxis extends LabelAxis {
     private final boolean dontExpandLabels;
 
     @DataBoundConstructor
-    public ElasticAxis(
-            String name, String labelString, boolean ignoreOffline, boolean dontExpandLabels) {
+    public ElasticAxis(String name, String labelString, boolean ignoreOffline, boolean dontExpandLabels) {
         super(name, computeAllNodesInLabel(labelString, dontExpandLabels));
         this.label = labelString;
         this.ignoreOffline = ignoreOffline;
@@ -86,8 +85,7 @@ public class ElasticAxis extends LabelAxis {
                 hudson.model.Label agentLabel = Jenkins.get().getLabel(aLabel.trim());
                 if (agentLabel != null) {
                     for (Node node : agentLabel.getNodes()) {
-                        if (shouldAddNode(restrictToOnlineNodes, node.toComputer()))
-                            onlineNodesForLabel = true;
+                        if (shouldAddNode(restrictToOnlineNodes, node.toComputer())) onlineNodesForLabel = true;
                     }
                     if (onlineNodesForLabel) {
                         computedNodes.add(agentLabel.getExpression());
@@ -125,28 +123,24 @@ public class ElasticAxis extends LabelAxis {
         }
 
         @RequirePOST
-        public FormValidation doCheckLabelString(
-                @AncestorInPath Job<?, ?> job, @QueryParameter String value) {
+        public FormValidation doCheckLabelString(@AncestorInPath Job<?, ?> job, @QueryParameter String value) {
             job.checkPermission(hudson.model.Item.CONFIGURE);
             String[] labels = value.split(",");
             List<FormValidation> aggregatedNotOkValidations = new ArrayList<>();
             for (String oneLabel : labels) {
                 FormValidation validation = LabelExpression.validate(oneLabel, job);
                 if (!validation.equals(FormValidation.ok())) {
-                    LOGGER.log(
-                            Level.FINEST,
-                            "Remembering not ok validation {1} for label {0}",
-                            new Object[] {oneLabel, validation});
+                    LOGGER.log(Level.FINEST, "Remembering not ok validation {1} for label {0}", new Object[] {
+                        oneLabel, validation
+                    });
                     aggregatedNotOkValidations.add(validation);
                 }
             }
             if (!aggregatedNotOkValidations.isEmpty()) {
-                FormValidation aggregatedValidations =
-                        FormValidation.aggregate(aggregatedNotOkValidations);
-                LOGGER.log(
-                        Level.FINEST,
-                        "Returning aggregated not ok validation {1} for labels {0}",
-                        new Object[] {labels, aggregatedValidations});
+                FormValidation aggregatedValidations = FormValidation.aggregate(aggregatedNotOkValidations);
+                LOGGER.log(Level.FINEST, "Returning aggregated not ok validation {1} for labels {0}", new Object[] {
+                    labels, aggregatedValidations
+                });
                 return aggregatedValidations;
             }
             LOGGER.log(Level.FINEST, "Returning ok validation for labels {0}", labels);

--- a/src/test/java/org/jenkinsci/plugins/elasticaxisplugin/ElasticAxisTest.java
+++ b/src/test/java/org/jenkinsci/plugins/elasticaxisplugin/ElasticAxisTest.java
@@ -28,7 +28,8 @@ import org.jvnet.hudson.test.JenkinsRule;
 @RunWith(Parameterized.class)
 public class ElasticAxisTest {
 
-    @ClassRule public static JenkinsRule j = new JenkinsRule();
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
 
     private final String axisName;
     private final String labelString;
@@ -79,15 +80,11 @@ public class ElasticAxisTest {
             for (Boolean doNotExpandLabels : possibleValues) {
                 for (String labelSuffix : LABEL_SUFFIXES) {
                     // Test for known agents
-                    Object[] argument = {
-                        AGENT_PREFIX + labelSuffix, ignoreOffline, doNotExpandLabels
-                    };
+                    Object[] argument = {AGENT_PREFIX + labelSuffix, ignoreOffline, doNotExpandLabels};
                     arguments.add(argument);
                 }
                 // Test that a non-existing agent matches nothing
-                Object[] argument = {
-                    AGENT_PREFIX + DOES_NOT_EXIST_SUFFIX, ignoreOffline, doNotExpandLabels
-                };
+                Object[] argument = {AGENT_PREFIX + DOES_NOT_EXIST_SUFFIX, ignoreOffline, doNotExpandLabels};
                 arguments.add(argument);
             }
         }
@@ -141,9 +138,7 @@ public class ElasticAxisTest {
     public void testGetValuesForController() {
         // selfLabel will be "master" before 2.307 and "built-in" after 2.307
         String expectedLabel = j.jenkins.getSelfLabel().getName();
-        elasticAxis =
-                new ElasticAxis(
-                        axisName, expectedLabel + " || built-in", ignoreOffline, doNotExpandLabels);
+        elasticAxis = new ElasticAxis(axisName, expectedLabel + " || built-in", ignoreOffline, doNotExpandLabels);
         if (doNotExpandLabels) {
             assertThat(elasticAxis.getValues(), hasItem(expectedLabel + "||built-in"));
         } else {
@@ -153,8 +148,7 @@ public class ElasticAxisTest {
 
     @Test
     public void testGetValuesForAgentAOrAgentB() {
-        elasticAxis =
-                new ElasticAxis(axisName, "label-A || label-B", ignoreOffline, doNotExpandLabels);
+        elasticAxis = new ElasticAxis(axisName, "label-A || label-B", ignoreOffline, doNotExpandLabels);
         if (doNotExpandLabels) {
             assertThat(elasticAxis.getValues(), hasItem("label-A||label-B"));
         } else {


### PR DESCRIPTION
## Use Palantir format instead of Google Java Format

From https://github.com/jenkinsci/cloud-stats-plugin/pull/68 :

Google Java Format is an excellent formatter for 2-space, 100 line codebases. Its Rectangle Rule has a high degree of conceptual purity, and this works well in the context of 2-space, 100 line codebases where it was designed. If starting from scratch, or if radical changes to existing code style were on the table, this would be my ideal formatter.

For existing 4-space, 120 line codebases where radical changes to existing code style are not on the table, Google Java Format has some critical flaws. Its 4-space "AOSP" mode does not work well at all, and it was not the primary use case. In practice the combination of 4-space mode and the rectangle rule results in unreadable code for lambdas. I have complained about this on the Google Java Format issue tracker for years, but no fix appears to be on the horizon. This makes sense, because Google internally uses the 2-space non-AOSP mode. While various PRs have been submitted to fix this problem, the maintainers of Google Java Format have rejected or ignored them, likely because they all violate the conceptual purity of the Rectangle Rule.

For existing 4-space, 120 line codebases (and the Jenkins project consists largely of these) where radical changes to existing code style are not on the table, Palantir Java Format is a better choice than Google Java Format. It is a fork of Google Java Format designed for this use case with intentional violations of the Rectangle Rule. In practice it gives much better results than Google Java Format for this type of codebase.

The Maven project is reformatting its legacy codebase with Palantir Java Format and I have been impressed with how relatively uneventful it has been. Palantir Java Format works very well with this type of codebase, and Jenkins is an example of this type of codebase as well. I have successfully reformatted plugin-compat-tester this way in jenkinsci/plugin-compat-tester#506 and the results are far better than Google Java Format.

As the Zen of Python states:

> Practicality beats purity

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
